### PR TITLE
scrolling background implementation

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,7 +13,6 @@
     <link rel="icon" href="/favicon.ico" type="image/x-icon"/>
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon"/>
   </head>
-
   <body>
     <div id="container">
       <div class="inner">
@@ -49,5 +48,6 @@
 
       </div>
     </div>
+    <script src="/assets/js/main.js"></script>
   </body>
 </html>

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -15,7 +15,6 @@
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon"/>
     <link rel="pgpkey" href="alex@littlenavmap.org.pubkey.asc"/>
   </head>
-
   <body>
     <div id="container">
       <div class="inner">
@@ -51,5 +50,6 @@
 
       </div>
     </div>
+    <script src="/assets/js/main.js"></script>
   </body>
 </html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,7 +13,6 @@
     <link rel="icon" href="/favicon.ico" type="image/x-icon"/>
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon"/>
   </head>
-
   <body>
     <div id="container">
       <div class="inner">
@@ -54,5 +53,6 @@
         </footer>
       </div>
     </div>
+    <script src="/assets/js/main.js"></script>
   </body>
 </html>

--- a/_layouts/privacy.html
+++ b/_layouts/privacy.html
@@ -27,5 +27,6 @@
         </footer>
       </div>
     </div>
+    <script src="/assets/js/main.js"></script>
   </body>
 </html>

--- a/_layouts/redirected.html
+++ b/_layouts/redirected.html
@@ -14,7 +14,6 @@
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon"/>
     <meta http-equiv="refresh" content="5; URL={{ page.redirect_to }}" />
   </head>
-
   <body>
     <div id="container">
       <div class="inner">
@@ -32,7 +31,6 @@
         </footer>
       </div>
     </div>
+    <script src="/assets/js/main.js"></script>
   </body>
 </html>
-
-

--- a/_layouts/subpage.html
+++ b/_layouts/subpage.html
@@ -13,7 +13,6 @@
     <link rel="icon" href="/favicon.ico" type="image/x-icon"/>
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon"/>
   </head>
-
   <body>
     <div id="container">
       <div class="inner">
@@ -51,5 +50,6 @@
 
       </div>
     </div>
+    <script src="/assets/js/main.js"></script>
   </body>
 </html>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -257,6 +257,7 @@ body {
     margin: 0;
     padding: 1cm;
     height: calc(100% - 2 * 1cm);
+    background-position-y: 0%;
 
 	@media (max-width: 768px) {
     	padding: .5cm;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,8 @@
+var inner = document.querySelector("#container>.inner");
+if(inner) {
+	inner.addEventListener("scroll", function() {
+		if(innerWidth > 1280) {
+			document.body.style.backgroundPositionY = inner.scrollTop / (inner.scrollHeight - inner.clientHeight) * 100 + "%";
+		}
+	});
+}


### PR DESCRIPTION
works on "Desktop" (> 1280px width) when background image of body has an aspect ratio being more portrait than the viewport, then its top is viewport top aligned when the scroll position is at top (of "inner" container) and its bottom becomes viewport bottom aligned when scrolling to bottom (of "inner" container).

https://user-images.githubusercontent.com/84718885/167456767-9336e483-e7dd-458a-bd58-af687db3b21e.mp4

